### PR TITLE
Upgrading to react@0.14.0 and a newer devpack

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 *.log
 *.js
+bundle.css
+*.html
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# component-stickymasthead
+> A sticky masthead

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+SSH_KEY="${1:-/root/.ssh/id_rsa}"
+DOCKER_IMAGE="economistprod/node4-base"
+
+[[ ${NPM_TOKEN:-} = '' ]] && { echo "NPM_TOKEN empty"; exit 1; }
+[[ ${SAUCE_ACCESS_KEY:-} = '' ]] && { echo "SAUCE_ACCESS_KEY empty"; exit 2; }
+
+docker pull "${DOCKER_IMAGE}"
+
+exec docker run \
+    -v "${SSH_KEY}":/root/.ssh/id_rsa \
+    -v "$(pwd)":/code \
+    "${DOCKER_IMAGE}" \
+    /bin/sh -cx "\
+        trap 'chmod 777 node_modules -R' EXIT && \
+        cd /code && \
+        umask 000 && \
+        printf \"@economist:registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n\" > ~/.npmrc && \
+        NODE_ENV=test npm i && \
+        echo SAUCE_USER=sublimino SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} npm t && \
+        { git config --global user.email 'ecprod@economist.com'; git config --global user.name 'GoCD'; true; } && \
+        { [ \"$(git rev-parse --abbrev-ref HEAD)\" != \"master\" ] || npm run pages; } ; \
+        RETURN_CODE=\$?; \
+        echo \"Build finished with status \${RETURN_CODE}\"; \
+        exit \${RETURN_CODE}
+    ";
+
+

--- a/example.es6
+++ b/example.es6
@@ -1,12 +1,10 @@
 import StickyMastHead from './index.es6';
 import React from 'react';
-import ShareBar from '@economist/component-sharebar';
 import Icon from '@economist/component-icon';
 
 export default (
   <StickyMastHead>
     <h1 className="wif-title sticky-hidden">The World</h1>
-    <ShareBar customClass="sticky-show"/>
     <div className="wif-button">
       <a href="/theWorldIf">
         <Icon

--- a/example.es6
+++ b/example.es6
@@ -9,8 +9,17 @@ export default (
     <ShareBar customClass="sticky-show"/>
     <div className="wif-button">
       <a href="/theWorldIf">
-        <Icon icon="home" className="home StickyMasthead--visible" background="none" size="100%"/>
-        <Icon icon="logoWorldIF" className="if StickyMasthead--hidden" size="100%"/>
+        <Icon
+          icon="home"
+          className="home StickyMasthead--visible"
+          background="none"
+          size="100%"
+        />
+        <Icon
+          icon="logoWorldIF"
+          className="if StickyMasthead--hidden"
+          size="100%"
+        />
       </a>
     </div>
   </StickyMastHead>

--- a/index.es6
+++ b/index.es6
@@ -23,13 +23,6 @@ export default class StickyMastHead extends React.Component {
       <Sticky
         className={`StickyMasthead ${this.props.className}`}
         topOffset={this.props.topOffset}
-        type={(attributes, children) => {
-          return (
-            <div {...attributes}>
-              {children}
-            </div>
-          );
-        }}
       >
         <MastHead>
           {this.props.children}

--- a/index.es6
+++ b/index.es6
@@ -23,6 +23,13 @@ export default class StickyMastHead extends React.Component {
       <Sticky
         className={`StickyMasthead ${this.props.className}`}
         topOffset={this.props.topOffset}
+        type={(attributes, children) => {
+          return (
+            <div {...attributes}>
+              {children}
+            </div>
+          );
+        }}
       >
         <MastHead>
           {this.props.children}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devpack-doc": {
     "demohtml": {
-      "cmd": "babel-node -p \"require('react').renderToString(require('./example'))\""
+      "cmd": "babel-node -p \"require('react-dom/server').renderToString(require('./example'))\""
     },
     "css": [
       {
@@ -62,7 +62,7 @@
         "contents": "window.React = require('react');"
       },
       {
-        "contents": "require('react-dom').render(require('example'),document.getElementById('component-preview'));"
+        "contents": "require('react').render(require('example'),document.getElementById('component-preview'));"
       },
       {
         "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
@@ -125,12 +125,11 @@
   "dependencies": {
     "@economist/component-icon": "^3.0.1",
     "@economist/component-masthead": "^2.1.3",
-    "react": "^0.13.3",
+    "react": "^0.14.1",
     "react-sticky": "^3.0.0"
   },
   "devDependencies": {
     "@economist/component-devpack": "^3.4.3",
-    "@economist/component-sharebar": "^1.3.0",
     "babel": "^5.8.23",
     "babelify": "^6.3.0",
     "browser-sync": "^2.8.2",
@@ -155,7 +154,7 @@
     "npm-watch": "0.0.1",
     "parallelshell": "^2.0.0",
     "pre-commit": "^1.0.10",
-    "react-dom": "^0.14.0",
+    "react-dom": "^0.14.1",
     "watchify": "^3.4.0"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -11,80 +11,152 @@
   "files": [
     "*.js",
     "*.css",
-    "assets/*"
+    "assets/*",
+    "!karma.conf.js",
+    "!testbundle.js"
   ],
-  "eslintConfig": {
-    "extends": "strict/react"
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   },
-  "component-devserver": {
-    "example": "./example.es6",
+  "babel": {
+    "stage": 0,
+    "loose": "all",
+    "compact": false
+  },
+  "eslintConfig": {
+    "extends": [
+      "strict",
+      "strict-react"
+    ]
+  },
+  "devpack-doc": {
+    "demohtml": {
+      "cmd": "babel-node -p \"require('react').renderToString(require('./example'))\""
+    },
     "css": [
-      "/node_modules/mocha/mocha.css",
-      "/index.css"
+      {
+        "src": "./node_modules/mocha/mocha.css"
+      },
+      "./bundle.css"
     ],
     "js": [
-      "/node_modules/react/react.js?browserify&expose=react",
       {
-        "contents": "window.React = require('react');"
+        "src": "./node_modules/mocha/mocha.js"
       },
-      "/index.es6?babelify&debug&expose=index.es6&external=react",
-      "/example.es6?babelify&debug&expose=example.es6&external=react",
       {
-        "contents": "require('react').render(require('example.es6'),document.getElementById('component-preview'));"
+        "src": "./node_modules/chai/chai.js"
       },
-      "/node_modules/mocha/mocha.js",
-      "/node_modules/@economist/component-testharness/node_modules/chai/chai.js",
-      "/node_modules/@economist/component-testharness/node_modules/chai-things/lib/chai-things.js",
-      "/node_modules/@economist/component-testharness/node_modules/chai-as-promised/lib/chai-as-promised.js",
-      "/node_modules/@economist/component-testharness/node_modules/chai-spies/chai-spies.js",
+      {
+        "src": "./node_modules/chai-things/lib/chai-things.js"
+      },
+      {
+        "src": "./node_modules/chai-spies/chai-spies.js"
+      },
       {
         "contents": "chai.should();mocha.setup('bdd');"
       },
-      "/test/index.es6?babelify&debug&external=react",
+      "./testbundle.js",
       {
-        "contents": "mocha.checkLeaks();mocha.run();"
+        "contents": "window.React = require('react');"
+      },
+      {
+        "contents": "require('react-dom').render(require('example'),document.getElementById('component-preview'));"
+      },
+      {
+        "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
       }
     ],
-    "html": [
+    "sections": [
       {
-        "contents": "<div class='component-panel'><h2 class='component-panel-heading'>Tests</h2><div id='mocha' class='test-output'></div></div>"
+        "title": "Readme",
+        "type": "markdown",
+        "src": "./README.md"
+      },
+      {
+        "title": "Example Code",
+        "type": "code",
+        "src": "./example.es6"
+      },
+      {
+        "title": "Tests",
+        "type": "html",
+        "contents": "<div id='mocha' class='test-output'></div>"
       }
     ]
   },
+  "watch": {
+    "doc:html": [
+      "README.md",
+      "./*.js",
+      "package.json"
+    ]
+  },
   "config": {
-    "lint_opts": "--ignore-path .gitignore --ext .es6"
+    "lint_opts": "--ignore-path .gitignore --ext .es6",
+    "testbundle_opts": "-r react -r .:./index.es6 -r ./example.js:example ./test/index.js -o testbundle.js",
+    "ghpages_files": "*.html *.css *.js assets/"
   },
   "scripts": {
     "build": "npm-assets .",
+    "ci": "./build.sh",
+    "doc": "parallelshell 'npm run doc:html' 'npm run doc:js' 'npm run doc:css'",
+    "doc:css": "cssnext --sourcemap example.css bundle.css",
+    "doc:css:watch": "npm run doc:css -- --watch",
+    "doc:html": "devpack-doc index standalone",
+    "doc:html:watch": "npm-watch",
+    "doc:js": "npm run prepublish && browserify -d $npm_package_config_testbundle_opts",
+    "doc:js:watch": "watchify $npm_package_config_testbundle_opts",
+    "doc:watch": "parallelshell 'npm run doc:html:watch' 'npm run doc:js:watch' 'npm run doc:css:watch'",
     "lint": "eslint $npm_package_config_lint_opts .",
-    "prepublish": "babel index.es6 --source-maps=inline --stage=0 --loose > index.js",
+    "pages": "git stash save -u pages-stash && git branch -D gh-pages; git checkout --orphan gh-pages && git add -f $npm_package_config_ghpages_files && git commit -anm'ghpages' && git push origin HEAD:gh-pages -f",
+    "prepages": "npm run build && npm run doc",
+    "prepublish": "babel . -d . -x .es6",
+    "prepublish:watch": "npm run prepublish -- -w",
+    "pretest": "npm run lint",
     "provision": "devpack-configure ./package.json",
-    "serve": "component-devserver .",
-    "test": "npm run test:base -- -R tap",
+    "serve": "browser-sync start --server --files '*.{html,js}'",
+    "test": "karma start",
     "test:base": "mocha -r babel/register -r @economist/component-testharness",
-    "test:watch": "npm run test:base -- -wR min"
+    "test:watch": "npm run test:base -- -wR min",
+    "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
     "@economist/component-icon": "^3.0.1",
     "@economist/component-masthead": "^2.1.3",
     "react": "^0.13.3",
-    "react-sticky": "^2.3.0"
+    "react-sticky": "^3.0.0"
   },
   "devDependencies": {
-    "@economist/component-devpack": "^2.5.0",
-    "@economist/component-devserver": "^2.0.0",
+    "@economist/component-devpack": "^3.4.3",
     "@economist/component-sharebar": "^1.3.0",
-    "@economist/component-testharness": "^1.1.0",
-    "babel": "^5.5.8",
-    "eslint": "^0.24.0",
-    "eslint-config-strict": "^2.4.0",
-    "eslint-plugin-filenames": "^0.1.1",
+    "babel": "^5.8.23",
+    "babelify": "^6.3.0",
+    "browser-sync": "^2.8.2",
+    "browserify": "^11.0.1",
+    "chai": "^3.2.0",
+    "chai-spies": "^0.6.0",
+    "chai-things": "^0.2.0",
+    "cssnext": "^1.8.4",
+    "eslint": "^1.3.1",
+    "eslint-config-strict": "^5.0.0",
+    "eslint-config-strict-react": "^2.0.0",
+    "eslint-plugin-filenames": "^0.1.2",
     "eslint-plugin-one-variable-per-var": "^0.0.3",
-    "eslint-plugin-react": "^2.6.3",
+    "eslint-plugin-react": "^3.3.1",
+    "karma": "^0.13.14",
+    "karma-chai": "^0.1.0",
+    "karma-mocha": "^0.2.0",
+    "karma-sauce-launcher": "^0.2.14",
     "minifyify": "^7.0.1",
     "mocha": "^2.2.5",
     "npm-assets": "^0.1.0",
-    "pre-commit": "^1.0.10"
+    "npm-watch": "0.0.1",
+    "parallelshell": "^2.0.0",
+    "pre-commit": "^1.0.10",
+    "react-dom": "^0.14.0",
+    "watchify": "^3.4.0"
   },
   "pre-commit": [
     "lint"

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,1 +1,1 @@
-{"extends":"strict/es6/mocha"}
+{"extends":["strict","strict-react","strict/mocha"]}


### PR DESCRIPTION
- [x] Upgraded to `react@0.14.0`.
- [x] Upgraded to the latest (released) devpack.
- [x] Implemented [weird workaround](https://github.com/sebinsua/component-stickymasthead/blob/a3978051faeaf60132202724f9fbe0dcd66ef844/index.es6#L26-L32) to get `react-sticky` to stop throwing `Error: Invariant Violation: ReactCompositeComponent.render(): A valid ReactComponent must be returned. You may have returned undefined, an array or some other invalid object` exceptions when running `npm run doc`. Please note, if there's a cleaner way of fixing this, then we can do so however it seems this will require a PR on somebody else's project.